### PR TITLE
[feat]: 카카오 소셜 로그인 토큰 검증 및 DB에 정보 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.cloud:spring-cloud-openfeign-docs:4.0.4'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/onnoff/onnoff/OnnoffApplication.java
+++ b/src/main/java/com/onnoff/onnoff/OnnoffApplication.java
@@ -2,7 +2,9 @@ package com.onnoff.onnoff;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class OnnoffApplication {
 

--- a/src/main/java/com/onnoff/onnoff/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/onnoff/onnoff/auth/client/KakaoApiClient.java
@@ -1,0 +1,21 @@
+package com.onnoff.onnoff.auth.client;
+
+import com.onnoff.onnoff.auth.client.dto.KakaoOauth2DTO;
+import feign.Headers;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/*
+ 토큰 유효성 검증하고 사용자 정보 가져오는 client
+ */
+@FeignClient(name = "kakao-api-client", url = "https://kapi.kakao.com")
+public interface KakaoApiClient {
+    @GetMapping("v1/user/access_token_info")
+    KakaoOauth2DTO.TokenValidateResponseDTO getTokenValidate(@RequestHeader("Authorization") String accessToken);
+    @PostMapping(value = "/v2/user/me")
+    @Headers("Content-Type: application/x-www-form-urlencoded")
+    KakaoOauth2DTO.UserInfoResponseDTO getUserInfo(@RequestHeader("Authorization") String accessToken, @RequestParam(name = "property_keys") String propertyKeys);
+
+}

--- a/src/main/java/com/onnoff/onnoff/auth/client/KakaoOauth2Client.java
+++ b/src/main/java/com/onnoff/onnoff/auth/client/KakaoOauth2Client.java
@@ -1,0 +1,19 @@
+package com.onnoff.onnoff.auth.client;
+
+
+import com.onnoff.onnoff.auth.client.dto.KakaoOauth2DTO;
+import feign.Headers;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name = "kakao-oauth2-client", url = "https://kauth.kakao.com")
+public interface KakaoOauth2Client {
+    @Headers("Content-Type: application/x-www-form-urlencoded")
+    @PostMapping("/oauth/token")
+    KakaoOauth2DTO.TokenResponseDTO getAccessToken(@RequestParam(name = "grant_type") String grantType,
+                                                   @RequestParam(name = "client_id") String clientId,
+                                                   @RequestParam(name = "redirect_uri") String redirectUri,
+                                                   @RequestParam(name = "code") String code
+    );
+
+}

--- a/src/main/java/com/onnoff/onnoff/auth/client/config/LoggingConfiguration.java
+++ b/src/main/java/com/onnoff/onnoff/auth/client/config/LoggingConfiguration.java
@@ -1,0 +1,13 @@
+package com.onnoff.onnoff.auth.client.config;
+
+import feign.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LoggingConfiguration {
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/auth/client/dto/KakaoOauth2DTO.java
+++ b/src/main/java/com/onnoff/onnoff/auth/client/dto/KakaoOauth2DTO.java
@@ -1,0 +1,55 @@
+package com.onnoff.onnoff.auth.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.auth.client.KakaoOauth2Client;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+public class KakaoOauth2DTO {
+
+    @Getter
+    public static class TokenResponseDTO{
+        @JsonProperty("token_type")
+        private String tokenType;
+        @JsonProperty("access_token")
+        private String accessToken;
+    }
+
+    @Getter
+    public static class TokenValidateResponseDTO{
+        private Long id;
+        @JsonProperty("expires_in")
+        private Integer expiresIn;
+        @JsonProperty("app_id")
+        private Integer appId;
+    }
+
+    @Getter
+    @ToString
+    public static class UserInfoResponseDTO{
+        private Long id;
+        @JsonProperty("connected_at")
+        private LocalDateTime connectedAt;
+        @JsonProperty("kakao_account")
+        private KakaoAccountDTO kakaoAccount;
+    }
+    @Getter
+    @ToString
+    public static class KakaoAccountDTO{
+        // 이메일 동의항목
+//        private boolean has_email;
+//        private boolean email_needs_agreement;
+//        private boolean is_email_valid;
+//        private boolean is_email_verified;
+        private String email;
+
+        // 이름 동의 항목
+//        private boolean name_needs_agreement;
+        private String name;
+
+
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
+++ b/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
@@ -1,0 +1,73 @@
+package com.onnoff.onnoff.auth.controller;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.auth.client.dto.KakaoOauth2DTO;
+import com.onnoff.onnoff.auth.dto.LoginResponseDTO;
+import com.onnoff.onnoff.auth.service.LoginService;
+import com.onnoff.onnoff.domain.user.User;
+import com.onnoff.onnoff.domain.user.converter.UserConverter;
+import com.onnoff.onnoff.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class LoginController {
+    private final LoginService loginService;
+    private final UserService userService;
+
+
+    /*
+    테스트용 API, CORS 때문에 직접 호출하지 않고 redirect
+     */
+    @GetMapping("/oauth2/authorize/kakao")
+    public String login(){
+        String redirectUri = UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", "32c0787d1b1e9fcabcc24af247903ba8")
+                .queryParam("redirect_uri", "http://localhost:8080/oauth2/login/kakao")
+                .toUriString();
+        return "redirect:" + redirectUri;
+    }
+    /*
+    테스트용 API
+     */
+    @GetMapping("/oauth2/login/kakao")
+    public ResponseEntity<String> getAccessToken(@RequestParam(name = "code") String code){
+        log.info("code = {}", code);
+        loginService.getAccessToken(code);
+        return ResponseEntity.ok("토큰 get");
+    }
+    /*
+    1. 토큰 유효성 검증
+    2. 사용자 정보 얻어오기
+    3. DB조회 및 추가
+     */
+    // 나중에 accessToken RequestBody로 받도록 수정
+    @GetMapping("/oauth2/kakao/token/validate")
+    public ApiResponse<Object> validateToken(@RequestParam String accessToken) throws JsonProcessingException {
+        accessToken = "Bearer " + accessToken;
+        // 토큰 검증
+        loginService.validate(accessToken);
+        // ok -> 유저 정보 가져오기, error -> 에러 응답 코드 반환
+        KakaoOauth2DTO.UserInfoResponseDTO userInfoResponseDTO = loginService.getUserInfo(accessToken);
+        // 유저 정보에 DB 조회하고 정보 있으면 응답만, 없으면 저장까지 이 두 경우의 성공 응답코드 다르게
+        Long oauthId = userInfoResponseDTO.getId();
+        if( userService.isExistByOauthId(oauthId)){
+            return ApiResponse.onSuccess(new Object()); //응답 DTO 만들어야함
+        }
+        else{
+            User user = UserConverter.toUser(userInfoResponseDTO);
+            userService.create(user);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/auth/dto/LoginResponseDTO.java
@@ -1,0 +1,5 @@
+package com.onnoff.onnoff.auth.dto;
+
+public class LoginResponseDTO {
+
+}

--- a/src/main/java/com/onnoff/onnoff/auth/service/LoginService.java
+++ b/src/main/java/com/onnoff/onnoff/auth/service/LoginService.java
@@ -1,0 +1,65 @@
+package com.onnoff.onnoff.auth.service;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.auth.client.KakaoApiClient;
+import com.onnoff.onnoff.auth.client.KakaoOauth2Client;
+import com.onnoff.onnoff.auth.client.dto.KakaoOauth2DTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Arrays;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoginService {
+    private final KakaoOauth2Client kakaoOauth2Client;
+    private final KakaoApiClient kakaoApiClient;
+
+    /*
+        테스트 용으로 만든거, 실제로는 프론트에서 처리해서 액세스 토큰만 가져다 줌
+    */
+    public void getAccessToken(String code){
+        KakaoOauth2DTO.TokenResponseDTO tokenResponseDTO = kakaoOauth2Client.getAccessToken("authorization_code",
+                "32c0787d1b1e9fcabcc24af247903ba8",
+                "http://localhost:8080/oauth2/login/kakao",
+                code);
+        log.info("token = {}", tokenResponseDTO.getAccessToken());
+    }
+    /*
+        토큰 유효성 검증, 유효하지 않으면 예외를 뱉도록, 아직 예외 처리는 구현 안됨
+     */
+    public ResponseEntity<String> validate(String accessToken){
+        try{
+            KakaoOauth2DTO.TokenValidateResponseDTO responseDTO = kakaoApiClient.getTokenValidate(accessToken);
+            log.info("validate response = {}", responseDTO);
+        }
+        catch (Exception e){
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+     /*
+        토큰으로 유저정보를 가져오는 메서드
+     */
+
+    public KakaoOauth2DTO.UserInfoResponseDTO getUserInfo(String accessToken) throws JsonProcessingException {
+        String emailProperty = "kakao_account.email";
+        String nameProperty = "kakao_account.name";
+        List<String> propertyKeysList = Arrays.asList(emailProperty, nameProperty);
+
+        // List -> JSON 형식으로 바꾸어 전달
+        ObjectMapper objectMapper = new ObjectMapper();
+        String propertyKeys = objectMapper.writeValueAsString(propertyKeysList);
+        KakaoOauth2DTO.UserInfoResponseDTO userInfoResponseDTO = kakaoApiClient.getUserInfo(accessToken, propertyKeys);
+        log.info("userInfoResponseDTO = {}", userInfoResponseDTO);
+        return userInfoResponseDTO;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/entity/Resolution.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/entity/Resolution.java
@@ -21,7 +21,7 @@ public class Resolution extends BaseEntity {
 
     @Column(length = 30)
     private String content;
-
+    @Column(name = "order_num")
     private Integer order;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/onnoff/onnoff/domain/user/User.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/User.java
@@ -1,6 +1,9 @@
 package com.onnoff.onnoff.domain.user;
 
 import com.onnoff.onnoff.domain.common.BaseEntity;
+import com.onnoff.onnoff.domain.off.feed.entity.Feed;
+import com.onnoff.onnoff.domain.off.feedImage.entity.FeedImage;
+import com.onnoff.onnoff.domain.off.memoir.entity.Memoir;
 import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
 import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
 import com.onnoff.onnoff.domain.user.enums.SocialType;
@@ -30,11 +33,18 @@ public class User extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    private Long oauthId;  //토큰으로 얻어온 정보로 유저를 조회할 때 사용
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0")
+    private boolean infoSet; //추가 정보 기입 여부
+
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, length = 10)
+    @Column(length = 10)
     private String nickname;
 
+    @Column(nullable = false)
     private String email;
 
     @Column(length = 30)
@@ -44,6 +54,7 @@ public class User extends BaseEntity {
     @Column(length = 30)
     private String job;
 
+    @Column(length = 30)
     private String experienceYear;
 
     @Column(columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'")
@@ -52,7 +63,7 @@ public class User extends BaseEntity {
 
     private LocalDateTime inactiveDate;
 
-    //@Column(columnDefinition = "BOOLEAN DEFAULT false") h2 테스트 전용
+    //@Column(columnDefinition = "BOOLEAN DEFAULT false") //h2 테스트 전용
     @Column(columnDefinition = "TINYINT(1) DEFAULT 0")
     private boolean receivePushNotification;
 
@@ -61,15 +72,15 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-//    private List<Memoir> memoirList = new ArrayList<>();
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-//    private List<Feed> feedList = new ArrayList<>();
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-//    private List<FeedImage> feedImageList = new ArrayList<>();
-//
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Memoir> memoirList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Feed> feedList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<FeedImage> feedImageList = new ArrayList<>();
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Resolution> resolutionList = new ArrayList<>();
 

--- a/src/main/java/com/onnoff/onnoff/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/converter/UserConverter.java
@@ -1,0 +1,15 @@
+package com.onnoff.onnoff.domain.user.converter;
+
+import com.onnoff.onnoff.auth.client.dto.KakaoOauth2DTO;
+import com.onnoff.onnoff.domain.user.User;
+
+public class UserConverter {
+    public static User toUser(KakaoOauth2DTO.UserInfoResponseDTO response){
+        KakaoOauth2DTO.KakaoAccountDTO kakaoAccount = response.getKakaoAccount();
+        return User.builder()
+                .oauthId(response.getId())
+                .email(kakaoAccount.getEmail())
+                .name(kakaoAccount.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.onnoff.onnoff.domain.user.repository;
 import com.onnoff.onnoff.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByOauthId(Long oauthId);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/user/service/UserService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/service/UserService.java
@@ -10,4 +10,6 @@ public interface UserService {
     public List<User> getUserList();
 
     public User getUser(Long id);
+
+    public boolean isExistByOauthId(Long oauthId);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/service/UserServiceImpl.java
@@ -28,4 +28,8 @@ public class UserServiceImpl implements UserService{
         );
         return user;
     }
+    @Override
+    public boolean isExistByOauthId(Long oauthId) {
+        return userRepository.findById(oauthId).isPresent();
+    }
 }


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- feat/#8

### 💡 작업동기

- 소셜 로그인 구현

### 🔑 주요 변경사항

- 로그인  컨트롤러, 서비스 구현 , 유저 엔티티 속성 추가, 카카오 API 호출하는 client 추가

### 💡 관련 이슈

- 예외응답 만들때 feign client에서 예외응답 정보 참조해서 만들어야 하는데 또 예외응답 통일해서 만들어야 해서 어떻게 해야할지 더 찾아보고 고민해야 할 것 같습니다..
