### PR TITLE
[feat]: 오늘의 다짐 API 구현

### DIFF
--- a/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
@@ -17,7 +17,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     // 멤버 관려 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다.");
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
+
+    // 오늘의 다짐 관련 에러
+    RESOLUTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "RESOLUTION4001", "오늘의 다짐이 없습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/onnoff/onnoff/apiPayload/exception/handler/ResolutionHandler.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/exception/handler/ResolutionHandler.java
@@ -1,0 +1,10 @@
+package com.onnoff.onnoff.apiPayload.exception.handler;
+
+import com.onnoff.onnoff.apiPayload.code.BaseErrorCode;
+import com.onnoff.onnoff.apiPayload.exception.GeneralException;
+
+public class ResolutionHandler extends GeneralException {
+    public ResolutionHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/common/BaseEntity.java
+++ b/src/main/java/com/onnoff/onnoff/domain/common/BaseEntity.java
@@ -1,10 +1,12 @@
 package com.onnoff.onnoff.domain.common;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -14,9 +16,10 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
     @CreatedDate
+    @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedBy
+    @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
-
 }

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/controller/ResolutionController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/controller/ResolutionController.java
@@ -27,7 +27,8 @@ public class ResolutionController {
     }
 
     @PostMapping("/")
-    public ApiResponse<ResolutionResponse.AddResultDTO> addResolution(@RequestParam(name = "userId") Long userId, @RequestParam(name = "date") LocalDate date,
+    public ApiResponse<ResolutionResponse.AddResultDTO> addResolution(@RequestParam(name = "userId") Long userId,
+                                                                      @RequestParam(name = "date") LocalDate date,
                                                                       @RequestBody @Valid ResolutionRequest.AddResolutionDTO request){
         Resolution resolution = resolutionService.addResolution(userId, date, request);
         return ApiResponse.onSuccess(ResolutionConverter.toAddResolutionResultDTO(resolution));
@@ -35,7 +36,8 @@ public class ResolutionController {
 
     @PostMapping("/modify")
     public ApiResponse<ResolutionResponse.ResolutionViewDTO> modifyResolution(@RequestParam(name = "userId") Long userId,
-                                                                              @RequestParam(name = "date") LocalDate date, @RequestBody @Valid List<ResolutionRequest.ResolutionDTO> requestList){
+                                                                              @RequestParam(name = "date") LocalDate date,
+                                                                              @RequestBody List< ResolutionRequest.@Valid ResolutionDTO> requestList){
         resolutionService.modifyResolution(userId, date, requestList);
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/controller/ResolutionController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/controller/ResolutionController.java
@@ -1,0 +1,50 @@
+package com.onnoff.onnoff.domain.on.resolution.controller;
+
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.domain.on.resolution.converter.ResolutionConverter;
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionRequest;
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionResponse;
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+import com.onnoff.onnoff.domain.on.resolution.service.ResolutionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/on/resolution")
+public class ResolutionController {
+    private final ResolutionService resolutionService;
+
+    @GetMapping("/")
+    public ApiResponse<ResolutionResponse.ResolutionViewDTO> getResolutions(@RequestParam(name = "userId") Long userId,
+                                                                            @RequestParam(name = "date") LocalDate date){
+        List<Resolution> resolutionList = resolutionService.getAll(userId, date);
+        return ApiResponse.onSuccess(ResolutionConverter.toResolutionViewDTO(userId, date, resolutionList));
+    }
+
+    @PostMapping("/")
+    public ApiResponse<ResolutionResponse.AddResultDTO> addResolution(@RequestParam(name = "userId") Long userId, @RequestParam(name = "date") LocalDate date,
+                                                                      @RequestBody @Valid ResolutionRequest.AddResolutionDTO request){
+        Resolution resolution = resolutionService.addResolution(userId, date, request);
+        return ApiResponse.onSuccess(ResolutionConverter.toAddResolutionResultDTO(resolution));
+    }
+
+    @PostMapping("/modify")
+    public ApiResponse<ResolutionResponse.ResolutionViewDTO> modifyResolution(@RequestParam(name = "userId") Long userId,
+                                                                              @RequestParam(name = "date") LocalDate date, @RequestBody @Valid List<ResolutionRequest.ResolutionDTO> requestList){
+        resolutionService.modifyResolution(userId, date, requestList);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @DeleteMapping("/{resolutionId}")
+    public ApiResponse<ResolutionResponse.AddResultDTO> deleteResolution(@RequestParam(name = "userId") Long userId,
+                                                                         @RequestParam(name = "date") LocalDate date,
+                                                                         @PathVariable(name = "resolutionId") Long resolutionId){
+        resolutionService.deleteResolution(userId, date, resolutionId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/converter/ResolutionConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/converter/ResolutionConverter.java
@@ -19,12 +19,6 @@ public class ResolutionConverter {
                .build();
     }
 
-    public static Resolution toModifyResolution(ResolutionRequest.ResolutionDTO request){
-        return Resolution.builder()
-                .content(request.getContent())
-                .order(request.getOrder())
-                .build();
-    }
 
     //entity to response
     public static ResolutionResponse.AddResultDTO toAddResolutionResultDTO(Resolution resolution){

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/converter/ResolutionConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/converter/ResolutionConverter.java
@@ -1,0 +1,52 @@
+package com.onnoff.onnoff.domain.on.resolution.converter;
+
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionRequest;
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionResponse;
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ResolutionConverter {
+    //request to entity
+    public static Resolution toAddResolution(LocalDate date, Long order, ResolutionRequest.AddResolutionDTO request){
+       return  Resolution.builder()
+               .date(date)
+               .order(order.intValue())
+               .content(request.getContent())
+               .build();
+    }
+
+    public static Resolution toModifyResolution(ResolutionRequest.ResolutionDTO request){
+        return Resolution.builder()
+                .content(request.getContent())
+                .order(request.getOrder())
+                .build();
+    }
+
+    //entity to response
+    public static ResolutionResponse.AddResultDTO toAddResolutionResultDTO(Resolution resolution){
+        return ResolutionResponse.AddResultDTO.builder()
+                .resolutionId(resolution.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static ResolutionResponse.ResolutionViewDTO toResolutionViewDTO(Long userId, LocalDate date, List<Resolution> resolutionList){
+        List<ResolutionResponse.ResolutionDTO> resolutionDTOList = resolutionList.stream()
+                .map(resolution -> ResolutionResponse.ResolutionDTO.builder()
+                        .resolutionId(resolution.getId())
+                        .order(resolution.getOrder())
+                        .content(resolution.getContent())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ResolutionResponse.ResolutionViewDTO.builder()
+                .userId(userId)
+                .date(date)
+                .resolutionDTOList(resolutionDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/dto/ResolutionRequest.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/dto/ResolutionRequest.java
@@ -1,14 +1,15 @@
 package com.onnoff.onnoff.domain.on.resolution.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
-import java.time.LocalDate;
-
 public class ResolutionRequest {
     @Getter
     public static class AddResolutionDTO{
+        @NotBlank
         @Size(max = 30)
         String content;
     }
@@ -16,8 +17,13 @@ public class ResolutionRequest {
 
     @Getter
     public static class ResolutionDTO{
+        @NotNull
         Long resolutionId;
+        @NotNull
+        @Min(value = 1)
         Integer order;
+        @NotBlank
+        @Size(max = 30, message = "30자 이하로 작성해주세요.")
         String content;
     }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/dto/ResolutionRequest.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/dto/ResolutionRequest.java
@@ -1,0 +1,23 @@
+package com.onnoff.onnoff.domain.on.resolution.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class ResolutionRequest {
+    @Getter
+    public static class AddResolutionDTO{
+        @Size(max = 30)
+        String content;
+    }
+    
+
+    @Getter
+    public static class ResolutionDTO{
+        Long resolutionId;
+        Integer order;
+        String content;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/dto/ResolutionResponse.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/dto/ResolutionResponse.java
@@ -1,0 +1,41 @@
+package com.onnoff.onnoff.domain.on.resolution.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ResolutionResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddResultDTO{
+        Long resolutionId;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResolutionViewDTO{
+        Long userId;
+        LocalDate date;
+        List<ResolutionDTO> resolutionDTOList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResolutionDTO{
+        Long resolutionId;
+        Integer order;
+        String content;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/entity/Resolution.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/entity/Resolution.java
@@ -22,9 +22,27 @@ public class Resolution extends BaseEntity {
     @Column(length = 30)
     private String content;
 
+    @Column(name = "order_num")
     private Integer order;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void setUser(User user){
+        if(this.user != null){
+            user.getResolutionList().remove(this);
+        }
+        this.user = user;
+        user.getResolutionList().add(this);
+    }
+
+    public void setOrder(Integer order){
+        this.order = order;
+    }
+
+    public void modifyResolution(Integer order, String content){
+        this.order = order;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/repository/ResolutionRepository.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/repository/ResolutionRepository.java
@@ -1,0 +1,14 @@
+package com.onnoff.onnoff.domain.on.resolution.repository;
+
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+import com.onnoff.onnoff.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ResolutionRepository extends JpaRepository<Resolution, Long> {
+    List<Resolution> findAllByUserAndDate(User user, LocalDate date);
+
+    Long countByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/service/ResolutionService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/service/ResolutionService.java
@@ -1,0 +1,18 @@
+package com.onnoff.onnoff.domain.on.resolution.service;
+
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionRequest;
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ResolutionService {
+
+    List<Resolution> getAll(Long userId, LocalDate date);
+
+    Resolution addResolution(Long userId, LocalDate date, ResolutionRequest.AddResolutionDTO request);
+
+    void modifyResolution(Long userId, LocalDate date, List<ResolutionRequest.ResolutionDTO> requestList);
+
+    void deleteResolution(Long userId, LocalDate date, Long resolutionId);
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/service/ResolutionServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/service/ResolutionServiceImpl.java
@@ -1,0 +1,79 @@
+package com.onnoff.onnoff.domain.on.resolution.service;
+
+import com.onnoff.onnoff.apiPayload.code.status.ErrorStatus;
+import com.onnoff.onnoff.apiPayload.exception.GeneralException;
+import com.onnoff.onnoff.apiPayload.exception.handler.ResolutionHandler;
+import com.onnoff.onnoff.domain.on.resolution.converter.ResolutionConverter;
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionRequest;
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+import com.onnoff.onnoff.domain.on.resolution.repository.ResolutionRepository;
+import com.onnoff.onnoff.domain.user.User;
+import com.onnoff.onnoff.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ResolutionServiceImpl implements ResolutionService{
+    private final UserRepository userRepository;
+    private final ResolutionRepository resolutionRepository;
+
+    @Override
+    public List<Resolution> getAll(Long userId, LocalDate date){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return resolutionRepository.findAllByUserAndDate(user, date).stream().toList();
+    }
+
+    @Override
+    @Transactional
+    public Resolution addResolution(Long userId, LocalDate date, ResolutionRequest.AddResolutionDTO request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Long order = resolutionRepository.countByUserAndDate(user, date);
+
+        Resolution resolution = ResolutionConverter.toAddResolution(date, order+1, request);
+        resolution.setUser(user);
+
+        return resolutionRepository.save(resolution);
+    }
+
+    @Override
+    @Transactional
+    public void modifyResolution(Long userId, LocalDate date, List<ResolutionRequest.ResolutionDTO> requestList){
+        for(ResolutionRequest.ResolutionDTO request : requestList){
+
+            Resolution resolutionToModify = resolutionRepository.findById(request.getResolutionId())
+                    .orElseThrow(() -> new ResolutionHandler(ErrorStatus.RESOLUTION_NOT_FOUND));
+            resolutionToModify.modifyResolution(request.getOrder(), request.getContent());
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteResolution(Long userId, LocalDate date, Long resolutionId){
+        Resolution resolutionToDelete = resolutionRepository.findById(resolutionId)
+                .orElseThrow(() -> new ResolutionHandler(ErrorStatus.RESOLUTION_NOT_FOUND));
+
+        //해당 resolution 아래 객체들 순서 당겨주기
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        List<Resolution> resolutionList = resolutionRepository.findAllByUserAndDate(user, date).stream().toList();
+
+        for(Resolution resolution : resolutionList){
+            if(resolution.getOrder() > resolutionToDelete.getOrder()){
+                resolution.setOrder(resolution.getOrder() - 1);
+            }
+        }
+
+
+        resolutionRepository.delete(resolutionToDelete);
+    }
+}


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #7 

### 💡 작업동기

- 오늘의 다짐 API 구현

### 🔑 주요 변경사항

- 오늘의 다짐 조회 View에 따른 조회 api
- 오늘의 다짐 추가 api
   (프론트 측에서 내용만 받아오고, 순서는 서버 쪽에서 계산하여 추가)
- 오늘의 다짐 수정 api
- 오늘의 다짐 삭제 api
   (한 개씩 삭제, 삭제 시 순서 재설정)

### 💡 관련 이슈

- 수정 시 예외처리해야되는 부분이 더 있을까요?
- 오늘의 다짐 같은 경우는 뷰가 따로 있어서 특정 날짜에 대한 내용이므로 날짜를 받아오도록 작성했습니다.
- 풀리 올리고 conflict 나는 부분 해결해서 머지 예정
