### PR TITLE
[fix]: 로그인 처리 로직 수정, JwtAuthfilter 적용 경로 수정

### DIFF
--- a/src/main/java/com/onnoff/onnoff/auth/config/WebConfig.java
+++ b/src/main/java/com/onnoff/onnoff/auth/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     public FilterRegistrationBean<JwtAuthFilter> jwtFilterRegistration() {
         FilterRegistrationBean<JwtAuthFilter> registration = new FilterRegistrationBean<>();
         registration.setFilter(new JwtAuthFilter(jwtTokenProvider)); // 필터 인스턴스 설정
-        registration.addUrlPatterns("/**");
+        registration.addUrlPatterns("/*"); //서블릿 컨택스트에서 /*는 모든 요청, /**는 인식되지 않음
         registration.setOrder(1); // 필터의 순서 설정. 값이 낮을수록 먼저 실행
         return registration;
     }
@@ -38,7 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addWebRequestInterceptor(openEntityManagerInViewInterceptor);
 
         registry.addInterceptor(new UserInterceptor(userService, jwtUtil))
-                .addPathPatterns("/**")
+                .addPathPatterns("/**") // 스프링 경로는 /*와 /**이 다름
                 .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**");
     }
 }

--- a/src/main/java/com/onnoff/onnoff/auth/config/WebConfig.java
+++ b/src/main/java/com/onnoff/onnoff/auth/config/WebConfig.java
@@ -40,6 +40,5 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new UserInterceptor(userService, jwtUtil))
                 .addPathPatterns("/**")
                 .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**");
-
     }
 }

--- a/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
+++ b/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
@@ -14,6 +14,9 @@ import com.onnoff.onnoff.domain.user.converter.UserConverter;
 import com.onnoff.onnoff.domain.user.dto.UserResponseDTO;
 import com.onnoff.onnoff.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +61,13 @@ public class LoginController {
     4. 응답 헤더에 Jwt 토큰 추가
      */
 
-    @Operation(summary = "토큰 검증 API",description = "토큰을 검증 하고 이에 대한 결과를 응답합니다. 추가 정보 입력 여부도 같이 응답합니다.")
+    @Operation(summary = "토큰 검증 API",description = "토큰을 검증 하고 이에 대한 결과를 응답합니다. 추가 정보 입력 여부도 같이 응답 합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "토큰 검증 성공," + " 추가 정보 기입이 필요합니다.",
+                    content = @Content(schema = @Schema(implementation = UserResponseDTO.ApiResponseLoginDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 검증 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponseDTO.ApiResponseUserDetailDTO.class)))
+    })
     @ResponseBody
     @PostMapping("/oauth2/kakao/token/validate")
     public ApiResponse<?> validateToken(HttpServletResponse response, @RequestBody String accessToken)  {

--- a/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
+++ b/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
@@ -62,7 +62,6 @@ public class LoginController {
     @ResponseBody
     @PostMapping("/oauth2/kakao/token/validate")
     public ApiResponse<?> validateToken(HttpServletResponse response, @RequestBody String accessToken)  {
-        accessToken = "Bearer " + accessToken;
         // 토큰 검증
         loginService.validate(accessToken);
         // ok -> 유저 정보 가져오기

--- a/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
+++ b/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
@@ -61,7 +61,7 @@ public class LoginController {
     @Operation(summary = "토큰 검증 API",description = "토큰을 검증 하고 이에 대한 결과를 응답합니다. 추가 정보 입력 여부도 같이 응답합니다.")
     @ResponseBody
     @PostMapping("/oauth2/kakao/token/validate")
-    public ApiResponse<UserResponseDTO.LoginDTO> validateToken(HttpServletResponse response, @RequestBody String accessToken)  {
+    public ApiResponse<?> validateToken(HttpServletResponse response, @RequestBody String accessToken)  {
         accessToken = "Bearer " + accessToken;
         // 토큰 검증
         loginService.validate(accessToken);
@@ -82,7 +82,7 @@ public class LoginController {
             response.addHeader("Access-Token", token.getAccessToken());
             response.addHeader("Refresh-Token", token.getRefreshToken());
             if(user.isInfoSet()){
-                return ApiResponse.onSuccess(UserConverter.toLoginDTO(user));
+                return ApiResponse.onSuccess(UserConverter.toUserDetailDTO(user));
             }
             return ApiResponse.of(SuccessStatus.NEED_USER_DETAIL, UserConverter.toLoginDTO(user));
         }

--- a/src/main/java/com/onnoff/onnoff/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/auth/dto/LoginResponseDTO.java
@@ -1,5 +1,0 @@
-package com.onnoff.onnoff.auth.dto;
-
-public class LoginResponseDTO {
-
-}

--- a/src/main/java/com/onnoff/onnoff/auth/feignClient/client/KakaoApiClient.java
+++ b/src/main/java/com/onnoff/onnoff/auth/feignClient/client/KakaoApiClient.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.*;
 /*
  토큰 유효성 검증하고 사용자 정보 가져오는 client
  */
+
 @FeignClient(name = "kakao-api-client", url = "https://kapi.kakao.com", configuration = FeignConfig.class)
 public interface KakaoApiClient {
     @GetMapping("v1/user/access_token_info")
     KakaoOauth2DTO.TokenValidateResponseDTO getTokenValidate(@RequestHeader("Authorization") String accessToken);
-    @PostMapping(value = "/v2/user/me")
-    @Headers("Content-Type: application/x-www-form-urlencoded")
+    @GetMapping(value = "/v2/user/me")
     KakaoOauth2DTO.UserInfoResponseDTO getUserInfo(@RequestHeader("Authorization") String accessToken, @RequestParam(name = "property_keys") String propertyKeys);
 
 }

--- a/src/main/java/com/onnoff/onnoff/auth/feignClient/dto/KakaoOauth2DTO.java
+++ b/src/main/java/com/onnoff/onnoff/auth/feignClient/dto/KakaoOauth2DTO.java
@@ -34,7 +34,7 @@ public class KakaoOauth2DTO {
         private LocalDateTime connectedAt;
         @JsonProperty("kakao_account")
         private KakaoAccountDTO kakaoAccount;
-        private SocialType socialType = SocialType.KAKAO;
+        private SocialType socialType;
     }
     @Getter
     @ToString

--- a/src/main/java/com/onnoff/onnoff/auth/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/onnoff/onnoff/auth/jwt/filter/JwtAuthFilter.java
@@ -28,6 +28,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final static String[] ignorePrefix = {"/swagger-ui", "/v3/api-docs", "/oauth2"};
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("url ={}", request.getRequestURI());
         // 지정된 Path는 건너뛰기
         String currentPath = request.getServletPath();
         for(String ignorePath: ignorePrefix){

--- a/src/main/java/com/onnoff/onnoff/auth/jwt/filter/UserInterceptor.java
+++ b/src/main/java/com/onnoff/onnoff/auth/jwt/filter/UserInterceptor.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -36,6 +37,7 @@ public class UserInterceptor implements HandlerInterceptor {
         }
         catch (IllegalArgumentException exception){
             // jwt 필터에서 검증된 토큰이라 예외 안나겠지만 없지만 혹시 모르니
+            response.sendError(HttpStatus.UNAUTHORIZED.value());
             return false;
         }
     }

--- a/src/main/java/com/onnoff/onnoff/auth/service/LoginService.java
+++ b/src/main/java/com/onnoff/onnoff/auth/service/LoginService.java
@@ -35,13 +35,21 @@ public class LoginService {
         토큰 유효성 검증, 유효하지 않으면 예외를 발생시키도록 처리, 예외는 CustomErrorDecoder에서 처리
      */
     public void validate(String accessToken){
-        kakaoApiClient.getTokenValidate(accessToken);
+        String cleanedAccessToken = cleanAccessToken(accessToken);
+        kakaoApiClient.getTokenValidate(cleanedAccessToken);
     }
 
+    private String cleanAccessToken(String accessToken){
+        accessToken = accessToken.replaceAll("[\u0000-\u001F\u007F-\u00FF:]", ""); // 헤더에 있으면 안되는 값 대체
+        accessToken = accessToken.trim(); // 앞뒤 공백 제거
+        accessToken = "Bearer " + accessToken; // 토큰 기반 인증 형식
+        return accessToken;
+    }
      /*
         토큰으로 유저정보를 가져오는 메서드
      */
     public KakaoOauth2DTO.UserInfoResponseDTO getUserInfo(String accessToken) throws JsonProcessingException {
+        String cleanedAccessToken = cleanAccessToken(accessToken);
         String emailProperty = "kakao_account.email";
         String nameProperty = "kakao_account.name";
         List<String> propertyKeysList = Arrays.asList(emailProperty, nameProperty);
@@ -49,7 +57,7 @@ public class LoginService {
         // List -> JSON 형식으로 바꾸어 전달
         ObjectMapper objectMapper = new ObjectMapper();
         String propertyKeys = objectMapper.writeValueAsString(propertyKeysList);
-        KakaoOauth2DTO.UserInfoResponseDTO userInfoResponseDTO = kakaoApiClient.getUserInfo(accessToken, propertyKeys);
+        KakaoOauth2DTO.UserInfoResponseDTO userInfoResponseDTO = kakaoApiClient.getUserInfo(cleanedAccessToken, propertyKeys);
         return userInfoResponseDTO;
     }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/user/User.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/User.java
@@ -27,7 +27,7 @@ import java.util.List;
 @Table(name = "users") // h2 DB에서 user가 예약어라 테이블명 살짝 변경
 public class User extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/onnoff/onnoff/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/converter/UserConverter.java
@@ -3,6 +3,7 @@ package com.onnoff.onnoff.domain.user.converter;
 import com.onnoff.onnoff.auth.feignClient.dto.KakaoOauth2DTO;
 import com.onnoff.onnoff.domain.user.User;
 import com.onnoff.onnoff.domain.user.dto.UserResponseDTO;
+import com.onnoff.onnoff.domain.user.enums.SocialType;
 
 public class UserConverter {
     public static User toUser(KakaoOauth2DTO.UserInfoResponseDTO response){
@@ -11,6 +12,7 @@ public class UserConverter {
                 .oauthId(response.getId())
                 .email(kakaoAccount.getEmail())
                 .name(kakaoAccount.getName())
+                .socialType(SocialType.KAKAO)
                 .build();
     }
 

--- a/src/main/java/com/onnoff/onnoff/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/dto/UserResponseDTO.java
@@ -1,5 +1,6 @@
 package com.onnoff.onnoff.domain.user.dto;
 
+import com.onnoff.onnoff.apiPayload.ApiResponse;
 import com.onnoff.onnoff.domain.user.enums.SocialType;
 import com.onnoff.onnoff.domain.user.enums.Status;
 import lombok.AllArgsConstructor;
@@ -39,5 +40,21 @@ public class UserResponseDTO {
         private SocialType socialType;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
+    }
+
+    /**
+     * 스웨거 response에 제네릭 타입을 써주기 위한 클래스
+     */
+    public static class ApiResponseLoginDTO extends ApiResponse<LoginDTO> {
+
+        public ApiResponseLoginDTO(Boolean isSuccess, String code, String message, LoginDTO result) {
+            super(isSuccess, code, message, result);
+        }
+    }
+    public static class ApiResponseUserDetailDTO extends  ApiResponse<UserDetailDTO>{
+
+        public ApiResponseUserDetailDTO(Boolean isSuccess, String code, String message, UserDetailDTO result) {
+            super(isSuccess, code, message, result);
+        }
     }
 }


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- feat/#8

### 💡 작업동기

- jwt필터가 동작을 안해서..
- 추가정보 기입 여부에 따라 응답DTO다르게 해주는거 깜빡했습니다
- 받아오는 검증할 토큰 값으로 \r\n\t 등 값 있으면 에러 터지더라구요


### 🔑 주요 변경사항

- jwtAuthFilter 적용 경로 수정
- 토큰 검증 응답 로직에 따라 응답 DTO 다르게 수정
- 유저 ID 생성전략 수정, 카카오 유저 정보 응답 받고 User로 바꿔줄 때 socialType 카카오로 set 하도록 수정
- 토큰 헤더값에 넣기전 clean하게 만들도록 수정
- 인터셉터에도 실패 시 401 응답 하도록 수정
- 스웨거 응답 추가
### 💡 관련 이슈

- 
