### PR TITLE
[feat]: 업무일지 관련 API 구현

### DIFF
--- a/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
@@ -19,7 +19,10 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
 
     // 오늘의 다짐 관련 에러
-    RESOLUTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "RESOLUTION4001", "오늘의 다짐이 없습니다."),
+    RESOLUTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "RESOLUTION4001", "해당하는 오늘의 다짐이 없습니다."),
+
+    //업무일지 관련 에러
+    WORKLOG_NOT_FOUND(HttpStatus.BAD_REQUEST, "WORKLOG4001", "해당하는 업무일지가 없습니다."),
 
     // 회고 질문 관련 에러
     QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "QUESTION4001", "해당하는 회고 질문이 없습니다."),

--- a/src/main/java/com/onnoff/onnoff/apiPayload/exception/handler/WorklogHandler.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/exception/handler/WorklogHandler.java
@@ -1,0 +1,10 @@
+package com.onnoff.onnoff.apiPayload.exception.handler;
+
+import com.onnoff.onnoff.apiPayload.code.BaseErrorCode;
+import com.onnoff.onnoff.apiPayload.exception.GeneralException;
+
+public class WorklogHandler extends GeneralException {
+    public WorklogHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/auth/config/WebConfig.java
+++ b/src/main/java/com/onnoff/onnoff/auth/config/WebConfig.java
@@ -39,6 +39,6 @@ public class WebConfig implements WebMvcConfigurer {
 
         registry.addInterceptor(new UserInterceptor(userService, jwtUtil))
                 .addPathPatterns("/**") // 스프링 경로는 /*와 /**이 다름
-                .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**");
+                .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**", "/on/**");
     }
 }

--- a/src/main/java/com/onnoff/onnoff/auth/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/onnoff/onnoff/auth/jwt/filter/JwtAuthFilter.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
-    private final static String[] ignorePrefix = {"/swagger-ui", "/v3/api-docs", "/oauth2"};
+    private final static String[] ignorePrefix = {"/swagger-ui", "/v3/api-docs", "/oauth2", "/on"};
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("url ={}", request.getRequestURI());

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/controller/ResolutionController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/controller/ResolutionController.java
@@ -6,6 +6,7 @@ import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionRequest;
 import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionResponse;
 import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
 import com.onnoff.onnoff.domain.on.resolution.service.ResolutionService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,7 @@ public class ResolutionController {
     private final ResolutionService resolutionService;
 
     @GetMapping("/")
+    @Operation(summary = "오늘의 다짐 조회 API")
     public ApiResponse<ResolutionResponse.ResolutionViewDTO> getResolutions(@RequestParam(name = "userId") Long userId,
                                                                             @RequestParam(name = "date") LocalDate date){
         List<Resolution> resolutionList = resolutionService.getAll(userId, date);
@@ -27,6 +29,7 @@ public class ResolutionController {
     }
 
     @PostMapping("/")
+    @Operation(summary = "오늘의 다짐 추가 API")
     public ApiResponse<ResolutionResponse.AddResultDTO> addResolution(@RequestParam(name = "userId") Long userId,
                                                                       @RequestBody @Valid ResolutionRequest.AddResolutionDTO request){
         Resolution resolution = resolutionService.addResolution(userId, request);
@@ -34,6 +37,7 @@ public class ResolutionController {
     }
 
     @PutMapping("/")
+    @Operation(summary = "오늘의 다짐 수정 API")
     public ApiResponse<ResolutionResponse.ResolutionViewDTO> modifyResolution(@RequestParam(name = "userId") Long userId,
                                                                               @RequestBody @Valid ResolutionRequest.ModifyResolutionDTO request){
         resolutionService.modifyResolution(userId, request);
@@ -41,6 +45,7 @@ public class ResolutionController {
     }
 
     @DeleteMapping("/{resolutionId}")
+    @Operation(summary = "오늘의 다짐 삭제 API")
     public ApiResponse<ResolutionResponse.AddResultDTO> deleteResolution(@RequestParam(name = "userId") Long userId,
                                                                          @RequestParam(name = "date") LocalDate date,
                                                                          @PathVariable(name = "resolutionId") Long resolutionId){

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/converter/ResolutionConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/converter/ResolutionConverter.java
@@ -11,9 +11,9 @@ import java.util.stream.Collectors;
 
 public class ResolutionConverter {
     //request to entity
-    public static Resolution toAddResolution(LocalDate date, Long order, ResolutionRequest.AddResolutionDTO request){
+    public static Resolution toAddResolution(Long order, ResolutionRequest.AddResolutionDTO request){
        return  Resolution.builder()
-               .date(date)
+               .date(request.getDate())
                .order(order.intValue())
                .content(request.getContent())
                .build();
@@ -24,7 +24,7 @@ public class ResolutionConverter {
     public static ResolutionResponse.AddResultDTO toAddResolutionResultDTO(Resolution resolution){
         return ResolutionResponse.AddResultDTO.builder()
                 .resolutionId(resolution.getId())
-                .createdAt(LocalDateTime.now())
+                .createdAt(resolution.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/onnoff/onnoff/domain/on/resolution/service/ResolutionServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/resolution/service/ResolutionServiceImpl.java
@@ -39,7 +39,7 @@ public class ResolutionServiceImpl implements ResolutionService{
 
         Long order = resolutionRepository.countByUserAndDate(user, request.getDate());
 
-        Resolution resolution = ResolutionConverter.toAddResolution(request.getDate(), order+1, request);
+        Resolution resolution = ResolutionConverter.toAddResolution(order+1, request);
         resolution.setUser(user);
 
         return resolutionRepository.save(resolution);

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/controller/OnController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/controller/OnController.java
@@ -1,0 +1,27 @@
+package com.onnoff.onnoff.domain.on.worklog.controller;
+
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.domain.on.worklog.dto.OnResponse;
+import com.onnoff.onnoff.domain.on.worklog.service.OnService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/on")
+public class OnController {
+    private final OnService onService;
+
+    @GetMapping("/")
+    @Operation(summary = "ON 화면 조회")
+    public ApiResponse<OnResponse.OnViewDTO> getOn(@RequestParam(name = "userId") Long userId,
+                                                   @RequestParam(name = "date", required = false) LocalDate date){
+        return ApiResponse.onSuccess(onService.getOn(userId, date));
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/controller/WorklogController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/controller/WorklogController.java
@@ -1,0 +1,61 @@
+package com.onnoff.onnoff.domain.on.worklog.controller;
+
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.domain.on.worklog.converter.WorklogConverter;
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogRequest;
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogResponse;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+import com.onnoff.onnoff.domain.on.worklog.service.WorklogService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/on/worklog")
+public class WorklogController {
+    private final WorklogService worklogService;
+
+
+    @PostMapping("/")
+    @Operation(summary = "업무일지 추가 API")
+    public ApiResponse<WorklogResponse.AddResultDTO> addWorklog(@RequestParam(name = "userId") Long userId,
+                                                                @RequestBody @Valid WorklogRequest.AddWorklogDTO request){
+        Worklog worklog = worklogService.addWorklog(userId, request);
+        return ApiResponse.onSuccess(WorklogConverter.toAddWorklogResultDTO(worklog));
+    }
+
+
+    @PostMapping("/{worklogId}")
+    @Operation(summary = "업무일지 수정 API")
+    public ApiResponse<WorklogResponse.ModifyResultDTO> modifyWorklog(@PathVariable(name = "worklogId") Long worklogId,
+                                                                      @RequestBody @Valid WorklogRequest.ModifyWorklogDTO request){
+        Worklog modifiedWorklog = worklogService.modifyContent(worklogId, request);
+        return ApiResponse.onSuccess(WorklogConverter.toModifyWorklogResultDTO(modifiedWorklog));
+    }
+
+
+    @PatchMapping("/{worklogId}")
+    @Operation(summary = "업무일지 내일로 미루기 API")
+    public ApiResponse<WorklogResponse.ModifyResultDTO> modifyWorklogDate(@PathVariable(name = "worklogId") Long worklogId){
+        Worklog modifiedWorklog = worklogService.modifyDate(worklogId);
+        return ApiResponse.onSuccess(WorklogConverter.toModifyWorklogResultDTO(modifiedWorklog));
+    }
+
+
+    @PutMapping("/{worklogId}")
+    @Operation(summary = "업무일지 체크 API")
+    public ApiResponse<WorklogResponse.ModifyResultDTO> modifyWorklogIsChecked(@PathVariable(name = "worklogId") Long worklogId){
+        Worklog modifiedWorklog = worklogService.modifyIsChecked(worklogId);
+        return ApiResponse.onSuccess(WorklogConverter.toModifyWorklogResultDTO(modifiedWorklog));
+    }
+
+
+    @DeleteMapping("/{worklogId}")
+    @Operation(summary = "업무일지 삭제 API")
+    public ApiResponse<WorklogResponse.AddResultDTO> deleteWorklog(@PathVariable(name = "worklogId") Long worklogId){
+        worklogService.deleteWorklog(worklogId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/converter/OnConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/converter/OnConverter.java
@@ -1,0 +1,55 @@
+package com.onnoff.onnoff.domain.on.worklog.converter;
+
+import com.onnoff.onnoff.domain.on.resolution.converter.ResolutionConverter;
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionResponse;
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+import com.onnoff.onnoff.domain.on.worklog.dto.OnResponse;
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogResponse;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class OnConverter {
+    public static OnResponse.OnViewDTO getOnDTO(Long userId, LocalDate date,
+                                                List<Resolution> resolutionList,
+                                                List<Worklog> worklogList){
+        LocalDate monday = date.minusDays(date.getDayOfWeek().getValue() - 1);
+
+        OnResponse.WeekDTO weekDTO =OnResponse.WeekDTO.builder()
+                .mon(monday)
+                .tue(monday.plusDays(1))
+                .wed(monday.plusDays(2))
+                .thu(monday.plusDays(3))
+                .fri(monday.plusDays(4))
+                .sat(monday.plusDays(5))
+                .sun(monday.plusDays(6))
+                .build();
+
+        List<ResolutionResponse.ResolutionDTO> resolutionDTOList = resolutionList.stream()
+                .map(resolution -> ResolutionResponse.ResolutionDTO.builder()
+                        .resolutionId(resolution.getId())
+                        .order(resolution.getOrder())
+                        .content(resolution.getContent())
+                        .build())
+                .collect(Collectors.toList());
+
+        List<WorklogResponse.WorklogDTO> worklogDTOList = worklogList.stream()
+                .map(worklog -> WorklogResponse.WorklogDTO.builder()
+                        .worklogId(worklog.getId())
+                        .content(worklog.getContent())
+                        .isChecked(worklog.getIsChecked())
+                        .build())
+                .collect(Collectors.toList());
+
+        return OnResponse.OnViewDTO.builder()
+                .userId(userId)
+                .date(date)
+                .week(weekDTO)
+                .resolutionDTOList(resolutionDTOList)
+                .worklogDTOList(worklogDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/converter/WorklogConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/converter/WorklogConverter.java
@@ -1,0 +1,35 @@
+package com.onnoff.onnoff.domain.on.worklog.converter;
+
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogRequest;
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogResponse;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+
+public class WorklogConverter {
+    //request to entity
+    public static Worklog toAddWorklog(WorklogRequest.AddWorklogDTO request){
+        return Worklog.builder()
+                .date(request.getDate())
+                .content(request.getContent())
+                .isChecked(false)
+                .build();
+    }
+
+
+    //entity to response
+    public static WorklogResponse.AddResultDTO toAddWorklogResultDTO(Worklog worklog){
+        return WorklogResponse.AddResultDTO.builder()
+                .worklogId(worklog.getId())
+                .createdAt(worklog.getCreatedAt())
+                .build();
+    }
+
+    public static WorklogResponse.ModifyResultDTO toModifyWorklogResultDTO(Worklog worklog){
+        return WorklogResponse.ModifyResultDTO.builder()
+                .worklogId(worklog.getId())
+                .content(worklog.getContent())
+                .date(worklog.getDate())
+                .isChecked(worklog.getIsChecked())
+                .updatedAt(worklog.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/dto/OnResponse.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/dto/OnResponse.java
@@ -1,0 +1,39 @@
+package com.onnoff.onnoff.domain.on.worklog.dto;
+
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionRequest;
+import com.onnoff.onnoff.domain.on.resolution.dto.ResolutionResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class OnResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WeekDTO{
+        LocalDate mon;
+        LocalDate tue;
+        LocalDate wed;
+        LocalDate thu;
+        LocalDate fri;
+        LocalDate sat;
+        LocalDate sun;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OnViewDTO{
+        Long userId;
+        LocalDate date;
+        WeekDTO week;
+        List<ResolutionResponse.ResolutionDTO> resolutionDTOList;
+        List<WorklogResponse.WorklogDTO> worklogDTOList;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/dto/WorklogRequest.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/dto/WorklogRequest.java
@@ -1,0 +1,26 @@
+package com.onnoff.onnoff.domain.on.worklog.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class WorklogRequest {
+    @Getter
+    public static class AddWorklogDTO{
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate date;
+        @NotBlank
+        @Size(max = 30)
+        String content;
+    }
+
+    @Getter
+    public static class ModifyWorklogDTO{
+        @NotBlank
+        @Size(max = 30)
+        String content;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/dto/WorklogResponse.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/dto/WorklogResponse.java
@@ -1,0 +1,42 @@
+package com.onnoff.onnoff.domain.on.worklog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class WorklogResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddResultDTO{
+        Long worklogId;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ModifyResultDTO{
+        Long worklogId;
+        LocalDate date;
+        String content;
+        Boolean isChecked;
+        LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WorklogDTO{
+        Long worklogId;
+        String content;
+        Boolean isChecked;
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/entity/Worklog.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/entity/Worklog.java
@@ -27,4 +27,24 @@ public class Worklog extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void setUser(User user){
+        if(this.user != null){
+            user.getWorklogList().remove(this);
+        }
+        this.user = user;
+        user.getWorklogList().add(this);
+    }
+
+    public void setIsChecked(){
+        this.isChecked= this.isChecked.equals(false);
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/repository/WorklogRepository.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/repository/WorklogRepository.java
@@ -1,0 +1,13 @@
+package com.onnoff.onnoff.domain.on.worklog.repository;
+
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+import com.onnoff.onnoff.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WorklogRepository extends JpaRepository<Worklog, Long> {
+    List<Worklog> findAllByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/OnService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/OnService.java
@@ -1,0 +1,9 @@
+package com.onnoff.onnoff.domain.on.worklog.service;
+
+import com.onnoff.onnoff.domain.on.worklog.dto.OnResponse;
+
+import java.time.LocalDate;
+
+public interface OnService {
+    public OnResponse.OnViewDTO getOn(Long userId, LocalDate date);
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/OnServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/OnServiceImpl.java
@@ -1,0 +1,43 @@
+package com.onnoff.onnoff.domain.on.worklog.service;
+
+import com.onnoff.onnoff.apiPayload.code.status.ErrorStatus;
+import com.onnoff.onnoff.apiPayload.exception.GeneralException;
+import com.onnoff.onnoff.domain.on.resolution.entity.Resolution;
+import com.onnoff.onnoff.domain.on.resolution.repository.ResolutionRepository;
+import com.onnoff.onnoff.domain.on.worklog.converter.OnConverter;
+import com.onnoff.onnoff.domain.on.worklog.dto.OnResponse;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+import com.onnoff.onnoff.domain.on.worklog.repository.WorklogRepository;
+import com.onnoff.onnoff.domain.user.User;
+import com.onnoff.onnoff.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OnServiceImpl implements OnService{
+    private final UserRepository userRepository;
+    private final ResolutionRepository resolutionRepository;
+    private final WorklogRepository worklogRepository;
+
+    @Override
+    public OnResponse.OnViewDTO getOn(Long userId, LocalDate date){
+        LocalDate localDate = Objects.requireNonNullElseGet(date, LocalDate::now);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Resolution> resolutionList = resolutionRepository.findAllByUserAndDate(user, localDate);
+
+        List<Worklog> worklogList = worklogRepository.findAllByUserAndDate(user, localDate);
+
+
+        return OnConverter.getOnDTO(userId, localDate, resolutionList, worklogList);
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/WorklogService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/WorklogService.java
@@ -1,0 +1,20 @@
+package com.onnoff.onnoff.domain.on.worklog.service;
+
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogRequest;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WorklogService {
+
+    Worklog addWorklog(Long userId, WorklogRequest.AddWorklogDTO request);
+
+    Worklog  modifyContent(Long worklogId, WorklogRequest.ModifyWorklogDTO request);
+
+    Worklog  modifyDate(Long worklogId);
+
+    Worklog  modifyIsChecked(Long worklogId);
+
+    void deleteWorklog(Long worklogId);
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/WorklogServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/WorklogServiceImpl.java
@@ -1,0 +1,70 @@
+package com.onnoff.onnoff.domain.on.worklog.service;
+
+import com.onnoff.onnoff.apiPayload.code.status.ErrorStatus;
+import com.onnoff.onnoff.apiPayload.exception.GeneralException;
+import com.onnoff.onnoff.apiPayload.exception.handler.WorklogHandler;
+import com.onnoff.onnoff.domain.on.worklog.converter.WorklogConverter;
+import com.onnoff.onnoff.domain.on.worklog.dto.WorklogRequest;
+import com.onnoff.onnoff.domain.on.worklog.entity.Worklog;
+import com.onnoff.onnoff.domain.on.worklog.repository.WorklogRepository;
+import com.onnoff.onnoff.domain.user.User;
+import com.onnoff.onnoff.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class WorklogServiceImpl implements WorklogService{
+    private final UserRepository userRepository;
+    private final WorklogRepository worklogRepository;
+
+    @Override
+    @Transactional
+    public Worklog addWorklog(Long userId, WorklogRequest.AddWorklogDTO request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Worklog worklog = WorklogConverter.toAddWorklog(request);
+        worklog.setUser(user);
+
+        return worklogRepository.save(worklog);
+    }
+
+    @Override
+    @Transactional
+    public Worklog  modifyContent(Long worklogId, WorklogRequest.ModifyWorklogDTO request){
+        Worklog worklogToModify = worklogRepository.findById(worklogId)
+                .orElseThrow(() -> new WorklogHandler(ErrorStatus.WORKLOG_NOT_FOUND));
+        worklogToModify.setContent(request.getContent());
+        return worklogToModify;
+    }
+
+    @Override
+    @Transactional
+    public Worklog  modifyDate(Long worklogId){
+        Worklog worklogToModify = worklogRepository.findById(worklogId)
+                .orElseThrow(() -> new WorklogHandler(ErrorStatus.WORKLOG_NOT_FOUND));
+        worklogToModify.setDate(worklogToModify.getDate().plusDays(1));
+        return worklogToModify;
+    }
+
+    @Override
+    @Transactional
+    public Worklog  modifyIsChecked(Long worklogId){
+        Worklog worklogToModify = worklogRepository.findById(worklogId)
+                .orElseThrow(() -> new WorklogHandler(ErrorStatus.WORKLOG_NOT_FOUND));
+        worklogToModify.setIsChecked();
+        return worklogToModify;
+    }
+
+    @Override
+    @Transactional
+    public void deleteWorklog(Long worklogId){
+        Worklog worklogToDelete = worklogRepository.findById(worklogId)
+                .orElseThrow(() -> new WorklogHandler(ErrorStatus.WORKLOG_NOT_FOUND));
+
+        worklogRepository.delete(worklogToDelete);
+    }
+}

--- a/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/WorklogServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/on/worklog/service/WorklogServiceImpl.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -46,7 +48,7 @@ public class WorklogServiceImpl implements WorklogService{
     public Worklog  modifyDate(Long worklogId){
         Worklog worklogToModify = worklogRepository.findById(worklogId)
                 .orElseThrow(() -> new WorklogHandler(ErrorStatus.WORKLOG_NOT_FOUND));
-        worklogToModify.setDate(worklogToModify.getDate().plusDays(1));
+        worklogToModify.setDate(LocalDate.now().plusDays(1));
         return worklogToModify;
     }
 


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #25 

### 💡 작업동기

- 업무일지 관련 API 구현

### 🔑 주요 변경사항

- On 화면 조회(해당 날짜 기준 일주일 날짜 정보, 오늘의 다짐 리스트, 업무일지 리스트)
- 업무일지 추가(isChecked false 세팅)
- 업무일지 내용 수정
- 업무일지 체크(해제 상태라면 체크, 체크 상태라면 체크 해제)
- 업무일지 내일로 미루기
- 업무일지 삭제

### 💡 관련 이슈

- 더 필요한 예외처리나 수정할 로직이 있다면 알려주시면 감사하겠습니다!
- user 찾아오는 건 로그인 파트 완료되면 일괄 수정할게요.
