### PR TITLE
[feat]: 요일 관련 API 구현

### DIFF
--- a/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
@@ -1,9 +1,24 @@
 package com.onnoff.onnoff.domain.weekday.controller;
 
+import com.onnoff.onnoff.apiPayload.ApiResponse;
+import com.onnoff.onnoff.domain.weekday.dto.WeekdayResponseDTO;
+import com.onnoff.onnoff.domain.weekday.service.WeekdayService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
 public class WeekdayController {
+
+    private final WeekdayService weekdayService;
+
+    @GetMapping("/weekdays/init")
+    @Operation(summary = "초기 요일 조회 API", description = "오늘 날짜를 기준으로 일주일을 조회하는 API입니다.")
+    public ApiResponse<WeekdayResponseDTO.WeekdayResultDTO> getInitWeekday() {
+        return ApiResponse.onSuccess(weekdayService.getWeekday(LocalDate.now()));
+    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
@@ -28,4 +28,10 @@ public class WeekdayController {
     public ApiResponse<WeekdayResponseDTO.WeekdayResultDTO> getPrevWeekday(@RequestParam(name = "date") LocalDate date) {
         return ApiResponse.onSuccess(weekdayService.getWeekday(date.minusDays(7)));
     }
+
+    @GetMapping("/weekdays/next")
+    @Operation(summary = "다음 주 요일 조회 API", description = "입력된 날짜를 기준으로 다음 일주일을 조회하는 API입니다. Query String으로 날짜를 입력해 주세요.")
+    public ApiResponse<WeekdayResponseDTO.WeekdayResultDTO> getNextWeekday(@RequestParam(name = "date") LocalDate date) {
+        return ApiResponse.onSuccess(weekdayService.getWeekday(date.plusDays(7)));
+    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
@@ -1,0 +1,9 @@
+package com.onnoff.onnoff.domain.weekday.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class WeekdayController {
+}

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/controller/WeekdayController.java
@@ -6,6 +6,7 @@ import com.onnoff.onnoff.domain.weekday.service.WeekdayService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
@@ -20,5 +21,11 @@ public class WeekdayController {
     @Operation(summary = "초기 요일 조회 API", description = "오늘 날짜를 기준으로 일주일을 조회하는 API입니다.")
     public ApiResponse<WeekdayResponseDTO.WeekdayResultDTO> getInitWeekday() {
         return ApiResponse.onSuccess(weekdayService.getWeekday(LocalDate.now()));
+    }
+
+    @GetMapping("/weekdays/prev")
+    @Operation(summary = "이전 주 요일 조회 API", description = "입력된 날짜를 기준으로 이전 일주일을 조회하는 API입니다. Query String으로 날짜를 입력해 주세요.")
+    public ApiResponse<WeekdayResponseDTO.WeekdayResultDTO> getPrevWeekday(@RequestParam(name = "date") LocalDate date) {
+        return ApiResponse.onSuccess(weekdayService.getWeekday(date.minusDays(7)));
     }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/dto/WeekdayResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/dto/WeekdayResponseDTO.java
@@ -1,0 +1,4 @@
+package com.onnoff.onnoff.domain.weekday.dto;
+
+public class WeekdayResponseDTO {
+}

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/dto/WeekdayResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/dto/WeekdayResponseDTO.java
@@ -1,4 +1,25 @@
 package com.onnoff.onnoff.domain.weekday.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
 public class WeekdayResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WeekdayResultDTO {
+        LocalDate monday;
+        LocalDate tuesday;
+        LocalDate wednesday;
+        LocalDate thursday;
+        LocalDate friday;
+        LocalDate saturday;
+        LocalDate sunday;
+    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayService.java
@@ -1,4 +1,10 @@
 package com.onnoff.onnoff.domain.weekday.service;
 
+import com.onnoff.onnoff.domain.weekday.dto.WeekdayResponseDTO;
+
+import java.time.LocalDate;
+
 public interface WeekdayService {
+
+    WeekdayResponseDTO.WeekdayResultDTO getWeekday(LocalDate date);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayService.java
@@ -1,0 +1,4 @@
+package com.onnoff.onnoff.domain.weekday.service;
+
+public interface WeekdayService {
+}

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayServiceImpl.java
@@ -1,0 +1,9 @@
+package com.onnoff.onnoff.domain.weekday.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WeekdayServiceImpl implements WeekdayService {
+}

--- a/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/weekday/service/WeekdayServiceImpl.java
@@ -1,9 +1,27 @@
 package com.onnoff.onnoff.domain.weekday.service;
 
+import com.onnoff.onnoff.domain.weekday.dto.WeekdayResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
 public class WeekdayServiceImpl implements WeekdayService {
+
+    @Override
+    public WeekdayResponseDTO.WeekdayResultDTO getWeekday(LocalDate date) {
+        LocalDate monday = date.minusDays(date.getDayOfWeek().getValue() - 1);
+
+        return WeekdayResponseDTO.WeekdayResultDTO.builder()
+                .monday(monday)
+                .tuesday(monday.plusDays(1))
+                .wednesday(monday.plusDays(2))
+                .thursday(monday.plusDays(3))
+                .friday(monday.plusDays(4))
+                .saturday(monday.plusDays(5))
+                .sunday(monday.plusDays(6))
+                .build();
+    }
 }


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #30 

### 💡 작업동기

- 일주일 단위로 날짜 정보를 조회하기 위한 API 구현

### 🔑 주요 변경사항

- 초기 요일 조회 API 구현
- 이전 주 요일 조회 API 구현
- 다음 주 요일 조회 API 구현

### 💡 관련 이슈

- 없음
