### PR TITLE
[fix]: 소셜 정보 조회 이름 조회 -> 닉네임 조회로 수정

### DIFF
--- a/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
+++ b/src/main/java/com/onnoff/onnoff/auth/controller/LoginController.java
@@ -44,6 +44,8 @@ public class LoginController {
 
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
 
 
 
@@ -54,7 +56,7 @@ public class LoginController {
     public String login(){
         String toRedirectUri = UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
                 .queryParam("response_type", "code")
-                .queryParam("client_id", "32c0787d1b1e9fcabcc24af247903ba8")
+                .queryParam("client_id", kakaoClientId)
                 .queryParam("redirect_uri", redirectUri)
                 .toUriString();
         return "redirect:" + toRedirectUri;

--- a/src/main/java/com/onnoff/onnoff/auth/feignClient/dto/kakao/KakaoOauth2DTO.java
+++ b/src/main/java/com/onnoff/onnoff/auth/feignClient/dto/kakao/KakaoOauth2DTO.java
@@ -20,7 +20,7 @@ public class KakaoOauth2DTO {
     @ToString
     public static class UserInfoResponseDTO{
         private String sub;
-        private String name;
+        private String nickname;
         private String email;
     }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/user/converter/UserConverter.java
@@ -11,7 +11,7 @@ public class UserConverter {
         return User.builder()
                 .oauthId(response.getSub())
                 .email(response.getEmail())
-                .name(response.getName())
+                .name(response.getNickname())
                 .socialType(SocialType.KAKAO)
                 .build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,10 @@
 spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            logger-level: FULL
   profiles:
     active: dev
   jwt:


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- fix/#46

### 💡 작업동기

- 카카오 테스트 앱이 아니라 실제 배포용 앱으로 바꾸면서 이름 가져오는 건 심사가 필요해서 일단 닉네임 가져오는 걸로 수정

### 🔑 주요 변경사항

- 닉네임 조회로 수정

### 💡 관련 이슈

- 배포 앱으로 바꾸면서 환경변수 KAKAO_CLIENT_ID, KAKAO_ADMIN_KEY 정보 바뀐걸로 로컬에서 테슽 가능하도록 노션에 갱신해놨고, 개발 인프라 환경에서 CLIENT_ID는 프론트 테스트용으로 네이티브 앱 키로 바꿔놨습니다!
