### PR TITLE
[feat]: 워라벨 피드 사진 관련 API 수정

### DIFF
--- a/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
@@ -42,10 +42,8 @@ public enum ErrorStatus implements BaseErrorCode {
     FEED_NOT_FOUND(HttpStatus.BAD_REQUEST, "FEED4001", "해당하는 워라벨 피드가 없습니다."),
 
     // 피드 사진 관련 에러
-    FEED_IMAGE_EXIST(HttpStatus.BAD_REQUEST, "FEEDIMAGE4001", "이미 해당 위치에 업로드된 워라벨 피드 사진이 있습니다."),
-    FEED_IMAGE_LOCATION_INVALID(HttpStatus.BAD_REQUEST, "FEEDIMAGE4002", "워라벨 피드 사진의 위치는 1에서 9 사이여야 합니다."),
-    FEED_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FEEDIMAGE4003", "해당하는 워라벨 피드 사진이 없습니다."),
-    FEED_IMAGE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FEEDIMAGE4004", "잘못된 형식의 파일입니다."),
+    FEED_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FEEDIMAGE4001", "해당하는 워라벨 피드 사진이 없습니다."),
+    FEED_IMAGE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FEEDIMAGE4002", "잘못된 형식의 파일입니다."),
 
     // 로그인 관련 에러
     INVALID_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "LOGIN4001", "토큰값이 잘못되었거나 유효하지 않습니다."),

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
@@ -18,10 +18,9 @@ public class FeedImageController {
     private final FeedImageService feedImageService;
 
     @PostMapping(value = "/feed-images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "워라벨 피드 사진 업로드 API",description = "워라벨 피드에 사진을 업로드하는 API입니다. Query String으로 사진 위치를 입력해 주세요.")
-    public ApiResponse<FeedImageResponseDTO.FeedImageResultDTO> uploadFeedImage(@RequestParam(name = "location") Integer location,
-                                                                       @RequestPart(name = "image") MultipartFile multipartFile) {
-        return ApiResponse.onSuccess(feedImageService.uploadFeedImage(location, multipartFile));
+    @Operation(summary = "워라벨 피드 사진 업로드 API",description = "워라벨 피드에 사진을 업로드하는 API입니다.")
+    public ApiResponse<FeedImageResponseDTO.FeedImageResultDTO> uploadFeedImage(@RequestPart(name = "image") MultipartFile multipartFile) {
+        return ApiResponse.onSuccess(feedImageService.uploadFeedImage(multipartFile));
     }
 
     @GetMapping("/feed-images")

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
@@ -24,7 +24,7 @@ public class FeedImageController {
     }
 
     @GetMapping("/feed-images")
-    @Operation(summary = "워라벨 피드 사진 조회 API",description = "워라벨 피드의 사진을 조회하는 API입니다. 위치를 기준으로 오름차순 정렬된 결과가 반환됩니다.")
+    @Operation(summary = "워라벨 피드 사진 조회 API",description = "워라벨 피드의 사진을 조회하는 API입니다. 생성 날짜 기준 오래된 순으로 정렬된 결과가 반환됩니다.")
     public ApiResponse<List<FeedImageResponseDTO.FeedImageResultDTO>> getFeedImage() {
         return ApiResponse.onSuccess(feedImageService.getFeedImage());
     }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
@@ -29,13 +29,6 @@ public class FeedImageController {
         return ApiResponse.onSuccess(feedImageService.getFeedImage());
     }
 
-    @PatchMapping(value = "/feed-images/{feedImageId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "워라벨 피드 사진 수정 API",description = "워라벨 피드의 사진을 수정하는 API입니다.")
-    public ApiResponse<FeedImageResponseDTO.FeedImageResultDTO> modifyFeedImage(@PathVariable(name = "feedImageId") Long feedImageId,
-                                                                       @RequestPart(name = "image") MultipartFile multipartFile) {
-        return ApiResponse.onSuccess(feedImageService.modifyFeedImage(feedImageId, multipartFile));
-    }
-
     @DeleteMapping("/feed-images/{feedImageId}")
     @Operation(summary = "워라벨 피드 사진 삭제 API",description = "워라벨 피드의 사진을 삭제하는 API입니다.")
     public ApiResponse<Long> deleteFeedImage(@PathVariable(name = "feedImageId") Long feedImageId) {

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
@@ -18,17 +18,16 @@ public class FeedImageController {
     private final FeedImageService feedImageService;
 
     @PostMapping(value = "/feed-images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "워라벨 피드 사진 업로드 API",description = "워라벨 피드에 사진을 업로드하는 API입니다. Query String으로 사용자 아이디와 사진 위치를 입력해 주세요.")
-    public ApiResponse<FeedImageResponseDTO.FeedImageResultDTO> uploadFeedImage(@RequestParam(name = "userId") Long userId,
-                                                                       @RequestParam(name = "location") Integer location,
+    @Operation(summary = "워라벨 피드 사진 업로드 API",description = "워라벨 피드에 사진을 업로드하는 API입니다. Query String으로 사진 위치를 입력해 주세요.")
+    public ApiResponse<FeedImageResponseDTO.FeedImageResultDTO> uploadFeedImage(@RequestParam(name = "location") Integer location,
                                                                        @RequestPart(name = "image") MultipartFile multipartFile) {
-        return ApiResponse.onSuccess(feedImageService.uploadFeedImage(userId, location, multipartFile));
+        return ApiResponse.onSuccess(feedImageService.uploadFeedImage(location, multipartFile));
     }
 
     @GetMapping("/feed-images")
-    @Operation(summary = "워라벨 피드 사진 조회 API",description = "워라벨 피드의 사진을 조회하는 API입니다. Query String으로 사용자 아이디를 입력해 주세요. 위치를 기준으로 오름차순 정렬된 결과가 반환됩니다.")
-    public ApiResponse<List<FeedImageResponseDTO.FeedImageResultDTO>> getFeedImage(@RequestParam(name = "userId") Long userId) {
-        return ApiResponse.onSuccess(feedImageService.getFeedImage(userId));
+    @Operation(summary = "워라벨 피드 사진 조회 API",description = "워라벨 피드의 사진을 조회하는 API입니다. 위치를 기준으로 오름차순 정렬된 결과가 반환됩니다.")
+    public ApiResponse<List<FeedImageResponseDTO.FeedImageResultDTO>> getFeedImage() {
+        return ApiResponse.onSuccess(feedImageService.getFeedImage());
     }
 
     @PatchMapping(value = "/feed-images/{feedImageId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/controller/FeedImageController.java
@@ -19,13 +19,13 @@ public class FeedImageController {
 
     @PostMapping(value = "/feed-images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "워라벨 피드 사진 업로드 API",description = "워라벨 피드에 사진을 업로드하는 API입니다.")
-    public ApiResponse<FeedImageResponseDTO.FeedImageResultDTO> uploadFeedImage(@RequestPart(name = "image") MultipartFile multipartFile) {
+    public ApiResponse<FeedImageResponseDTO.FeedImageDTO> uploadFeedImage(@RequestPart(name = "image") MultipartFile multipartFile) {
         return ApiResponse.onSuccess(feedImageService.uploadFeedImage(multipartFile));
     }
 
     @GetMapping("/feed-images")
     @Operation(summary = "워라벨 피드 사진 조회 API",description = "워라벨 피드의 사진을 조회하는 API입니다. 생성 날짜 기준 오래된 순으로 정렬된 결과가 반환됩니다.")
-    public ApiResponse<List<FeedImageResponseDTO.FeedImageResultDTO>> getFeedImage() {
+    public ApiResponse<List<FeedImageResponseDTO.FeedImageDTO>> getFeedImage() {
         return ApiResponse.onSuccess(feedImageService.getFeedImage());
     }
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/converter/FeedImageConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/converter/FeedImageConverter.java
@@ -5,8 +5,8 @@ import com.onnoff.onnoff.domain.off.feedImage.entity.FeedImage;
 
 public class FeedImageConverter {
 
-    public static FeedImageResponseDTO.FeedImageResultDTO toResultDTO(FeedImage feedImage, String imageUrl) {
-        return FeedImageResponseDTO.FeedImageResultDTO.builder()
+    public static FeedImageResponseDTO.FeedImageDTO toFeedImageDTO(FeedImage feedImage, String imageUrl) {
+        return FeedImageResponseDTO.FeedImageDTO.builder()
                 .feedImageId(feedImage.getId())
                 .imageUrl(imageUrl)
                 .build();

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/converter/FeedImageConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/converter/FeedImageConverter.java
@@ -8,7 +8,6 @@ public class FeedImageConverter {
     public static FeedImageResponseDTO.FeedImageResultDTO toResultDTO(FeedImage feedImage, String imageUrl) {
         return FeedImageResponseDTO.FeedImageResultDTO.builder()
                 .feedImageId(feedImage.getId())
-                .location(feedImage.getLocation())
                 .imageUrl(imageUrl)
                 .build();
     }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/dto/FeedImageRequestDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/dto/FeedImageRequestDTO.java
@@ -1,4 +1,0 @@
-package com.onnoff.onnoff.domain.off.feedImage.dto;
-
-public class FeedImageRequestDTO {
-}

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/dto/FeedImageResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/dto/FeedImageResponseDTO.java
@@ -13,7 +13,6 @@ public class FeedImageResponseDTO {
     @AllArgsConstructor
     public static class FeedImageResultDTO {
         Long feedImageId;
-        Integer location;
         String imageUrl;
     }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/dto/FeedImageResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/dto/FeedImageResponseDTO.java
@@ -11,7 +11,7 @@ public class FeedImageResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class FeedImageResultDTO {
+    public static class FeedImageDTO {
         Long feedImageId;
         String imageUrl;
     }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/entity/FeedImage.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/entity/FeedImage.java
@@ -16,9 +16,6 @@ public class FeedImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Integer location;
-
     @Column(nullable = false, length = 1024)
     private String imageKey;
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/entity/FeedImage.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/entity/FeedImage.java
@@ -23,7 +23,4 @@ public class FeedImage extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public void setImageKey(String imageKey) {
-        this.imageKey = imageKey;
-    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/repository/FeedImageRepository.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/repository/FeedImageRepository.java
@@ -9,6 +9,5 @@ import java.util.Optional;
 
 public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
 
-    Optional<FeedImage> findByUserAndLocation(User user, Integer location);
     List<FeedImage> findByUserOrderByLocationAsc(User user);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/repository/FeedImageRepository.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/repository/FeedImageRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
 
-    List<FeedImage> findByUserOrderByLocationAsc(User user);
+    List<FeedImage> findByUserOrderByCreatedAtAsc(User user);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 public interface FeedImageService {
 
-    FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(Long userId, Integer location, MultipartFile multipartFile);
+    FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(Integer location, MultipartFile multipartFile);
 
-    List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage(Long userId);
+    List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage();
 
     FeedImageResponseDTO.FeedImageResultDTO modifyFeedImage(Long feedImageId, MultipartFile multipartFile);
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 public interface FeedImageService {
 
-    FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(MultipartFile multipartFile);
+    FeedImageResponseDTO.FeedImageDTO uploadFeedImage(MultipartFile multipartFile);
 
-    List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage();
+    List<FeedImageResponseDTO.FeedImageDTO> getFeedImage();
 
     Long deleteFeedImage(Long feedImageId);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface FeedImageService {
 
-    FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(Integer location, MultipartFile multipartFile);
+    FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(MultipartFile multipartFile);
 
     List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage();
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageService.java
@@ -12,7 +12,5 @@ public interface FeedImageService {
 
     List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage();
 
-    FeedImageResponseDTO.FeedImageResultDTO modifyFeedImage(Long feedImageId, MultipartFile multipartFile);
-
     Long deleteFeedImage(Long feedImageId);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
@@ -54,7 +54,7 @@ public class FeedImageServiceImpl implements FeedImageService {
     @Transactional(readOnly = true)
     public List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage() {
         User user = UserContext.getUser();
-        List<FeedImage> feedImageList = feedImageRepository.findByUserOrderByLocationAsc(user);
+        List<FeedImage> feedImageList = feedImageRepository.findByUserOrderByCreatedAtAsc(user);
 
         return feedImageList.stream()
                 .map(feedImage -> FeedImageConverter.toResultDTO(feedImage, amazonS3Client.getUrl(bucket, feedImage.getImageKey()).toString()))

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.onnoff.onnoff.apiPayload.code.status.ErrorStatus;
 import com.onnoff.onnoff.apiPayload.exception.GeneralException;
+import com.onnoff.onnoff.auth.UserContext;
 import com.onnoff.onnoff.domain.off.feedImage.converter.FeedImageConverter;
 import com.onnoff.onnoff.domain.off.feedImage.dto.FeedImageResponseDTO;
 import com.onnoff.onnoff.domain.off.feedImage.entity.FeedImage;
@@ -32,14 +33,12 @@ public class FeedImageServiceImpl implements FeedImageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
     private final AmazonS3Client amazonS3Client;
-
     private final FeedImageRepository feedImageRepository;
-    private final UserRepository userRepository;
 
     @Override
     @Transactional
-    public FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(Long userId, Integer location, MultipartFile multipartFile) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    public FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(Integer location, MultipartFile multipartFile) {
+        User user = UserContext.getUser();
         if (feedImageRepository.findByUserAndLocation(user, location).isPresent()) {
             throw new GeneralException(ErrorStatus.FEED_IMAGE_EXIST);
         }
@@ -61,8 +60,8 @@ public class FeedImageServiceImpl implements FeedImageService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    public List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage() {
+        User user = UserContext.getUser();
         List<FeedImage> feedImageList = feedImageRepository.findByUserOrderByLocationAsc(user);
 
         return feedImageList.stream()

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
@@ -63,17 +63,6 @@ public class FeedImageServiceImpl implements FeedImageService {
 
     @Override
     @Transactional
-    public FeedImageResponseDTO.FeedImageResultDTO modifyFeedImage(Long feedImageId, MultipartFile multipartFile) {
-        FeedImage feedImage = feedImageRepository.findById(feedImageId).orElseThrow(() -> new GeneralException(ErrorStatus.FEED_IMAGE_NOT_FOUND));
-
-        deleteImage(feedImage.getImageKey());
-        feedImage.setImageKey(uploadImage(multipartFile));
-
-        return FeedImageConverter.toResultDTO(feedImage, amazonS3Client.getUrl(bucket, feedImage.getImageKey()).toString());
-    }
-
-    @Override
-    @Transactional
     public Long deleteFeedImage(Long feedImageId) {
         FeedImage feedImage = feedImageRepository.findById(feedImageId).orElseThrow(() -> new GeneralException(ErrorStatus.FEED_IMAGE_NOT_FOUND));
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
@@ -37,7 +37,7 @@ public class FeedImageServiceImpl implements FeedImageService {
 
     @Override
     @Transactional
-    public FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(MultipartFile multipartFile) {
+    public FeedImageResponseDTO.FeedImageDTO uploadFeedImage(MultipartFile multipartFile) {
         User user = UserContext.getUser();
 
         FeedImage feedImage = FeedImage.builder()
@@ -47,17 +47,17 @@ public class FeedImageServiceImpl implements FeedImageService {
 
         feedImageRepository.save(feedImage);
 
-        return FeedImageConverter.toResultDTO(feedImage, amazonS3Client.getUrl(bucket, feedImage.getImageKey()).toString());
+        return FeedImageConverter.toFeedImageDTO(feedImage, amazonS3Client.getUrl(bucket, feedImage.getImageKey()).toString());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<FeedImageResponseDTO.FeedImageResultDTO> getFeedImage() {
+    public List<FeedImageResponseDTO.FeedImageDTO> getFeedImage() {
         User user = UserContext.getUser();
         List<FeedImage> feedImageList = feedImageRepository.findByUserOrderByCreatedAtAsc(user);
 
         return feedImageList.stream()
-                .map(feedImage -> FeedImageConverter.toResultDTO(feedImage, amazonS3Client.getUrl(bucket, feedImage.getImageKey()).toString()))
+                .map(feedImage -> FeedImageConverter.toFeedImageDTO(feedImage, amazonS3Client.getUrl(bucket, feedImage.getImageKey()).toString()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/feedImage/service/FeedImageServiceImpl.java
@@ -37,19 +37,11 @@ public class FeedImageServiceImpl implements FeedImageService {
 
     @Override
     @Transactional
-    public FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(Integer location, MultipartFile multipartFile) {
+    public FeedImageResponseDTO.FeedImageResultDTO uploadFeedImage(MultipartFile multipartFile) {
         User user = UserContext.getUser();
-        if (feedImageRepository.findByUserAndLocation(user, location).isPresent()) {
-            throw new GeneralException(ErrorStatus.FEED_IMAGE_EXIST);
-        }
-
-        if (location < 1 | location > 9) {
-            throw new GeneralException(ErrorStatus.FEED_IMAGE_LOCATION_INVALID);
-        }
 
         FeedImage feedImage = FeedImage.builder()
                 .user(user)
-                .location(location)
                 .imageKey(uploadImage(multipartFile))
                 .build();
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,10 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 cloud:
   aws:
     s3:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
     password: ${DEV_DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #50 

### 💡 작업동기

- 워라벨 피드 사진 기능과 관련된 API 수정 및 삭제

### 🔑 주요 변경사항

- 토큰으로 유저 정보 조회
- 피드 사진 위치 데이터 삭제
- 피드 사진 조회 API에서 오래된 순으로 정렬
- 피드 사진 수정 API 삭제
- 피드 사진 관련 DTO명 수정

### 💡 관련 이슈

- 없음
