### PR TITLE
[feat]: 애플 로그인 구현

### DIFF
--- a/.ebextensions_dev/00-makeFiles.config
+++ b/.ebextensions_dev/00-makeFiles.config
@@ -7,6 +7,9 @@ files:
             #!/usr/bin/env bash
             JAR_PATH=/var/app/current/application.jar
 
+            # Copy keyfile from S3
+            aws s3 cp s3://onnoff-dev-s3/auth/AuthKey_5P49UCUSNW.p8 /var/app/current/src/main/resources/AuthKey_5P49UCUSNW.p8
+
             # run app
             killall java
             java -Dfile.encoding=UTF-8 -jar $JAR_PATH

--- a/src/main/java/com/onnoff/onnoff/auth/service/AppleLoginService.java
+++ b/src/main/java/com/onnoff/onnoff/auth/service/AppleLoginService.java
@@ -46,8 +46,6 @@ public class AppleLoginService implements LoginService{
     private String iss;
     @Value("${apple.team-id}")
     private String teamId;
-    @Value("${apple.redirect-uri}")
-    private String redirectUri;
     @Override
     public TokenResponse getAccessTokenByCode(String code) {
         // client secret 만들기
@@ -56,9 +54,8 @@ public class AppleLoginService implements LoginService{
         MultiValueMap<String, String> urlEncoded = TokenRequest.builder()
                 .clientId(clientId)
                 .clientSecret(clientSecret)
-                .code("authorization_code_value")
+                .code(code)
                 .grantType("authorization_code")
-                .redirectUri(redirectUri)
                 .build().toUrlEncoded();
         return appleAuthClient.getToken(urlEncoded);
     }
@@ -94,7 +91,6 @@ public class AppleLoginService implements LoginService{
                 .clientSecret(clientSecret)
                 .refreshToken(appleRefreshToken)
                 .grantType("refresh_token")
-                .redirectUri(redirectUri)
                 .build().toUrlEncoded();
         TokenResponse response = appleAuthClient.getToken(urlEncoded);
         return null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ apple:
   team-id: ${APPLE_TEAM_ID} # =  ID prefix
   key:
     id: ${APPLE_KEY_ID}
-    path: classpath:/apple/AuthKey_${APPLE_KEY_ID}.p8 # 나중에 src/main/resources/apple/에 키 파일 저장, 그냥 문자열로 가져와도 될 것 같기도
+    path: classpath:/AuthKey_${APPLE_KEY_ID}.p8 # 나중에 src/main/resources/apple/에 키 파일 저장, 그냥 문자열로 가져와도 될 것 같기도
 kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   iss: https://kauth.kakao.com


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- feat/#24

### 💡 작업동기

- 애플 로그인 구현

### 🔑 주요 변경사항

- CI/CD 배포 시에 resources에 애플 키 파일 추가
- 애플 액세스 토큰 받아오는 파라미터 수정(redirectUri 뺌)

### 💡 관련 이슈

- 애플은 로컬 테스트가 안돼서 배포 후에 프론트랑 연동해서 테스트 하면서 잘 동작하는지 확인해보겠습니다
- 키 파일 생성 원하는 위치에 되는지 부터 일단 확인해 봐야 할거 같네요

