### PR TITLE
[feat]: 회고 관련 API 수정

### DIFF
--- a/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
@@ -34,7 +34,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 회고 답변 관련 에러
     ANSWER_NOT_FOUND(HttpStatus.BAD_REQUEST, "ANSWER4001", "해당하는 회고 답변이 없습니다."),
-    ANSWER_BAD_MATCH(HttpStatus.BAD_REQUEST, "ANSWER4002", "해당하는 회고에 속하는 회고 답변이 아닙니다."),
 
     // 이모티콘 관련 에러
     EMOTICON_NOT_FOUND(HttpStatus.BAD_REQUEST, "EMOTICON4001", "해당하는 이모티콘이 없습니다."),

--- a/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onnoff/onnoff/apiPayload/code/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 회고 답변 관련 에러
     ANSWER_NOT_FOUND(HttpStatus.BAD_REQUEST, "ANSWER4001", "해당하는 회고 답변이 없습니다."),
+    ANSWER_EXIST(HttpStatus.BAD_REQUEST, "ANSWER4002", "이미 해당 질문으로 작성된 회고 답변이 있습니다."),
 
     // 이모티콘 관련 에러
     EMOTICON_NOT_FOUND(HttpStatus.BAD_REQUEST, "EMOTICON4001", "해당하는 이모티콘이 없습니다."),

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/converter/MemoirConverter.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/converter/MemoirConverter.java
@@ -40,7 +40,7 @@ public class MemoirConverter {
     public static List<MemoirResponseDTO.MemoirAnswerDTO> toMemoirAnswerDTOList(List<MemoirAnswer> memoirAnswerList) {
         return memoirAnswerList.stream()
                 .map(memoirAnswer -> MemoirResponseDTO.MemoirAnswerDTO.builder()
-                        .answerId(memoirAnswer.getId())
+                        .questionId(memoirAnswer.getMemoirQuestion().getId())
                         .question(memoirAnswer.getMemoirQuestion().getQuestion())
                         .summary(memoirAnswer.getMemoirQuestion().getSummary())
                         .answer(memoirAnswer.getAnswer())

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/dto/MemoirRequestDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/dto/MemoirRequestDTO.java
@@ -17,16 +17,7 @@ public class MemoirRequestDTO {
         @NotNull
         Long emoticonId;
         @NotNull
-        List<@Valid MemoirWriteAnswerDTO> memoirAnswerList;
-    }
-
-    @Getter
-    public static class MemoirWriteAnswerDTO {
-        @NotNull
-        Long questionId;
-        @NotNull
-        @Size(max = 500)
-        String answer;
+        List<@Valid MemoirAnswerDTO> memoirAnswerList;
     }
 
     @Getter
@@ -34,13 +25,13 @@ public class MemoirRequestDTO {
         @NotNull
         Long emoticonId;
         @NotNull
-        List<@Valid MemoirUpdateAnswerDTO> memoirAnswerList;
+        List<@Valid MemoirAnswerDTO> memoirAnswerList;
     }
 
     @Getter
-    public static class MemoirUpdateAnswerDTO {
+    public static class MemoirAnswerDTO {
         @NotNull
-        Long answerId;
+        Long questionId;
         @NotNull
         @Size(max = 500)
         String answer;

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/dto/MemoirResponseDTO.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/dto/MemoirResponseDTO.java
@@ -27,7 +27,7 @@ public class MemoirResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MemoirAnswerDTO {
-        Long answerId;
+        Long questionId;
         String question;
         String summary;
         String answer;

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/entity/Memoir.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/entity/Memoir.java
@@ -43,12 +43,4 @@ public class Memoir extends BaseEntity {
     public void setIsBookmarked(Boolean isBookmarked) {
         this.isBookmarked = isBookmarked;
     }
-
-    public void setUser(User user) {
-        this.user = user;
-    }
-
-    public void setMemoirAnswerList(List<MemoirAnswer> memoirAnswerList) {
-        this.memoirAnswerList = memoirAnswerList;
-    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/entity/MemoirAnswer.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/entity/MemoirAnswer.java
@@ -29,9 +29,4 @@ public class MemoirAnswer extends BaseEntity {
     public void setAnswer(String answer) {
         this.answer = answer;
     }
-
-    public void setMemoir(Memoir memoir) {
-        this.memoir = memoir;
-        memoir.getMemoirAnswerList().add(this);
-    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/entity/MemoirAnswer.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/entity/MemoirAnswer.java
@@ -29,4 +29,9 @@ public class MemoirAnswer extends BaseEntity {
     public void setAnswer(String answer) {
         this.answer = answer;
     }
+
+    public void setMemoir(Memoir memoir) {
+        this.memoir = memoir;
+        memoir.getMemoirAnswerList().add(this);
+    }
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/repository/MemoirAnswerRepository.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/repository/MemoirAnswerRepository.java
@@ -1,10 +1,16 @@
 package com.onnoff.onnoff.domain.off.memoir.repository;
 
+import com.onnoff.onnoff.domain.off.memoir.entity.Memoir;
 import com.onnoff.onnoff.domain.off.memoir.entity.MemoirAnswer;
+import com.onnoff.onnoff.domain.off.memoir.entity.MemoirQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemoirAnswerRepository extends JpaRepository<MemoirAnswer, Long> {
+
+    Optional<MemoirAnswer> findByMemoirAndMemoirQuestion(Memoir memoir, MemoirQuestion memoirQuestion);
+
     List<MemoirAnswer> findAllByMemoirId(Long memoirid);
 }

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/service/MemoirServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/service/MemoirServiceImpl.java
@@ -89,11 +89,9 @@ public class MemoirServiceImpl implements MemoirService {
 
         memoir.setEmoticon(emoticonRepository.findById(request.getEmoticonId()).orElseThrow(() -> new MemoirHandler(ErrorStatus.EMOTICON_NOT_FOUND)));
 
-        for (MemoirRequestDTO.MemoirUpdateAnswerDTO memoirAnswer : request.getMemoirAnswerList()) {
-            MemoirAnswer findMemoirAnswer = memoirAnswerRepository.findById(memoirAnswer.getAnswerId()).orElseThrow(() -> new MemoirHandler(ErrorStatus.ANSWER_NOT_FOUND));
-            if (findMemoirAnswer.getMemoir() != memoir) {
-                throw new MemoirHandler(ErrorStatus.ANSWER_BAD_MATCH);
-            }
+        for (MemoirRequestDTO.MemoirAnswerDTO memoirAnswer : request.getMemoirAnswerList()) {
+            MemoirQuestion memoirQuestion = memoirQuestionRepository.findById(memoirAnswer.getQuestionId()).orElseThrow(() -> new MemoirHandler(ErrorStatus.QUESTION_NOT_FOUND));
+            MemoirAnswer findMemoirAnswer = memoirAnswerRepository.findByMemoirAndMemoirQuestion(memoir, memoirQuestion).orElseThrow(() -> new MemoirHandler(ErrorStatus.ANSWER_NOT_FOUND));
             findMemoirAnswer.setAnswer(memoirAnswer.getAnswer().trim());
         }
 

--- a/src/main/java/com/onnoff/onnoff/domain/off/memoir/service/MemoirServiceImpl.java
+++ b/src/main/java/com/onnoff/onnoff/domain/off/memoir/service/MemoirServiceImpl.java
@@ -61,10 +61,11 @@ public class MemoirServiceImpl implements MemoirService {
 
             MemoirAnswer newMemoirAnswer = MemoirAnswer.builder()
                     .answer(memoirAnswer.getAnswer().trim())
+                    .memoir(newMemoir)
                     .memoirQuestion(memoirQuestion)
                     .build();
 
-            newMemoirAnswer.setMemoir(newMemoir);
+            newMemoir.getMemoirAnswerList().add(newMemoirAnswer);
             memoirAnswerRepository.save(newMemoirAnswer);
         }
 


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #83 

### 💡 작업동기

- 회고 답변을 식별하기 위해 답변 아이디 대신 연관된 질문 아이디를 사용하는 것으로 변경
- 질문으로 회고 답변을 식별하기 위해 하나의 회고 내에서 동일한 질문에 2개 이상 답변 불가능하도록 변경

### 🔑 주요 변경사항

- 회고 관련 API 응답 데이터 수정
- 회고 수정 API 요청 데이터 수정
- 동일한 질문에 중복 답변 불가로 수정

### 💡 관련 이슈

- 없음
