### PR TITLE
[hotfix] : 푸시알람 2개씩 가던 오류 수정

### DIFF
--- a/src/main/java/com/onnoff/onnoff/domain/push/service/FcmSendNotificationService.java
+++ b/src/main/java/com/onnoff/onnoff/domain/push/service/FcmSendNotificationService.java
@@ -39,6 +39,7 @@ public class FcmSendNotificationService {
         List<User> users = pushNotificationSettings.stream()
                 .filter(alarmSetting -> isMatchingDay(alarmSetting, today))
                 .map(PushNotificationSetting::getUser)
+                .distinct()
                 .toList();
         users.forEach(user -> {
             NotificationMessage notificationMessage = NotificationMessage.toGoHomeNotification(user);


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- feat/#90

### 💡 작업동기

- 푸시알람이 두개씩 보내짐.

### 🔑 주요 변경사항

- list에 distinct 함수 추가

### 💡 관련 이슈

- #90 
